### PR TITLE
claudecode: Add configurable permission restrictions to GitHub Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,23 @@ jobs:
 | `run-every-commit` | Run ClaudeCode on every commit (skips cache check). Warning: May increase false positives on PRs with many commits. | `false` | No |
 | `false-positive-filtering-instructions` | Path to custom false positive filtering instructions text file | None | No |
 | `custom-security-scan-instructions` | Path to custom security scan instructions text file to append to audit prompt | None | No |
+| `allowed-tools` | Comma-separated list of tools Claude Code can use (e.g., `"Read,Grep,LS,Bash(git diff:*)"`). If not specified, uses default read-only tools. | See below | No |
+
+#### Default Allowed Tools
+
+When `allowed-tools` is not specified, the action uses these read-only tools by default:
+- `Read` - Read file contents
+- `Glob` - Search for files by pattern
+- `Grep` - Search file contents
+- `LS` - List directory contents
+- `Task` - Create subtasks for analysis
+- `Bash(git diff:*)` - View git diffs
+- `Bash(git status:*)` - Check git status
+- `Bash(git log:*)` - View git history
+- `Bash(git show:*)` - Show git objects
+- `Bash(git remote show:*)` - Show remote information
+
+These defaults ensure Claude Code can analyze code without making any modifications.
 
 ### Action Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,11 @@ inputs:
     required: false
     default: ''
 
+  allowed-tools:
+    description: 'Comma-separated list of tools Claude Code is allowed to use (e.g., "Read,Grep,LS,Bash(git diff:*),Bash(git status:*)"). If not specified, uses default read-only tools for security scanning.'
+    required: false
+    default: ''
+
 outputs:
   findings-count:
     description: 'Number of security findings'
@@ -175,6 +180,7 @@ runs:
         FALSE_POSITIVE_FILTERING_INSTRUCTIONS: ${{ inputs.false-positive-filtering-instructions }}
         CUSTOM_SECURITY_SCAN_INSTRUCTIONS: ${{ inputs.custom-security-scan-instructions }}
         CLAUDE_MODEL: ${{ inputs.claude-model }}
+        ALLOWED_TOOLS: ${{ inputs.allowed-tools }}
       run: |
         echo "Running ClaudeCode AI security analysis..."
         echo "----------------------------------------"

--- a/claudecode/github_action_audit.py
+++ b/claudecode/github_action_audit.py
@@ -227,6 +227,15 @@ class SimpleClaudeRunner:
                 '--model', DEFAULT_CLAUDE_MODEL
             ]
             
+            # Add allowed tools if specified
+            allowed_tools = os.environ.get('ALLOWED_TOOLS', '').strip()
+            if not allowed_tools:
+                # Default read-only tools for security scanning
+                allowed_tools = 'Read,Glob,Grep,LS,Task,Bash(git diff:*),Bash(git status:*),Bash(git log:*),Bash(git show:*),Bash(git remote show:*)'
+            
+            # Claude CLI handles comma-separated list directly
+            cmd.extend(['--allowedTools', allowed_tools])
+            
             # Run Claude Code with retry logic
             NUM_RETRIES = 3
             for attempt in range(NUM_RETRIES):


### PR DESCRIPTION
- Add 'allowed-tools' input parameter to action.yml for configuring Claude Code permissions
- Implement --allowedTools flag passing in github_action_audit.py
- Set secure read-only defaults (Read, Glob, Grep, LS, Task, limited git commands)
- Add tests for permission restrictions functionality
- Update documentation with new parameter and default tools list
- Claude CLI handles comma-separated tool specifications natively

This enables tighter security controls while allowing flexibility to extend permissions for tools like Notion MCP when needed.

## Test Plan
- Added comprehensive tests for default and custom tool configurations
- Verified claude CLI handles tools with commas in specifications correctly
- All existing tests pass