### PR TITLE
github: Update GitHub Actions to use Figma forked versions

### DIFF
--- a/.github/workflows/test-claudecode.yml
+++ b/.github/workflows/test-claudecode.yml
@@ -18,15 +18,15 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: figma/actions-checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: figma/actions-setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
       with:
         python-version: '3.10'
     
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: figma/actions-setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
       with:
         node-version: '20'
     
@@ -45,7 +45,7 @@ jobs:
         pytest claudecode -v --cov=claudecode --cov-report=term-missing
     
     - name: Install Bun
-      uses: oven-sh/setup-bun@v2
+      uses: figma/actions-setup-bun@54cb141c5c91e2fdc396be3155a391f28e1822eb # v2
       with:
         bun-version: latest
     


### PR DESCRIPTION
## Summary
- Replace standard GitHub Actions with Figma's forked versions for improved security
- Update actions/checkout@v4 → figma/actions-checkout@11bd71901bbe5b1630ceea73d27597364c9af683
- Update actions/setup-python@v4 → figma/actions-setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3  
- Update actions/setup-node@v4 → figma/actions-setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
- Update oven-sh/setup-bun@v2 → figma/actions-setup-bun@54cb141c5c91e2fdc396be3155a391f28e1822eb

All actions now use pinned commit SHAs following Figma security practices.

## Test Plan
- [x] Verify workflow runs successfully with new Figma forked actions
- [x] Confirm all setup steps (Python, Node.js, Bun) work correctly  
- [x] Test that ClaudeCode tests and script tests continue to pass