### PR TITLE
claudecode: Fix test expectation for allowedTools parameter

### DIFF
--- a/claudecode/test_claude_runner.py
+++ b/claudecode/test_claude_runner.py
@@ -166,7 +166,9 @@ class TestSimpleClaudeRunner:
         assert call_args[0][0] == [
             'claude',
             '--output-format', 'json',
-            '--model', DEFAULT_CLAUDE_MODEL
+            '--model', DEFAULT_CLAUDE_MODEL,
+            '--allowedTools',
+            'Read,Glob,Grep,LS,Task,Bash(git diff:*),Bash(git status:*),Bash(git log:*),Bash(git show:*),Bash(git remote show:*)'
         ]
         assert call_args[1]['input'] == 'test prompt'
         assert call_args[1]['cwd'] == Path('/tmp/test')


### PR DESCRIPTION
## Summary
- Fixed failing test in `test_claude_runner.py` that was expecting the old Claude command format
- The `SimpleClaudeRunner.run_security_audit` method now includes `--allowedTools` parameter but the test assertion wasn't updated
- Updated `test_run_security_audit_success` to expect the `--allowedTools` parameter with its default security scanning tools

## Test Plan
- [x] Ran the specific failing test: `python3 -m pytest claudecode/test_claude_runner.py::TestSimpleClaudeRunner::test_run_security_audit_success -v` ✅
- [x] Ran all tests in the test file: `python3 -m pytest claudecode/test_claude_runner.py -v` ✅ (22 passed)
- [x] Ran full test suite: `python3 -m pytest --tb=short` ✅ (175 passed, 0 failed)