### PR TITLE
action: Fix workflow_dispatch support in GitHub Action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,11 @@ inputs:
     description: 'Comma-separated list of tools Claude Code is allowed to use (e.g., "Read,Grep,LS,Bash(git diff:*),Bash(git status:*)"). If not specified, uses default read-only tools for security scanning.'
     required: false
     default: ''
+  
+  pr-number:
+    description: 'Override PR number (useful for workflow_dispatch events)'
+    required: false
+    default: ''
 
 outputs:
   findings-count:
@@ -173,7 +178,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ github.token }}
         GITHUB_REPOSITORY: ${{ github.repository }}
-        PR_NUMBER: ${{ github.event.pull_request.number }}
+        PR_NUMBER: ${{ inputs.pr-number || github.event.pull_request.number || '' }}
         ANTHROPIC_API_KEY: ${{ inputs.claude-api-key }}
         ENABLE_CLAUDE_FILTERING: 'true' 
         EXCLUDE_DIRECTORIES: ${{ inputs.exclude-directories }}
@@ -189,9 +194,9 @@ runs:
         echo "findings_count=0" >> $GITHUB_OUTPUT
         echo "results_file=claudecode/claudecode-results.json" >> $GITHUB_OUTPUT
         
-        # Skip ClaudeCode if not a PR
-        if [ "${{ github.event_name }}" != "pull_request" ]; then
-          echo "ClaudeCode only runs on pull requests, skipping"
+        # Skip ClaudeCode if not a PR or workflow_dispatch
+        if [ "${{ github.event_name }}" != "pull_request" ] && [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
+          echo "ClaudeCode only runs on pull requests or workflow_dispatch, skipping"
           exit 0
         fi
                 


### PR DESCRIPTION
## Summary
- Allow the action to run on workflow_dispatch events in addition to pull_request events
- Added pr-number input parameter to override PR number for workflow_dispatch usage
- Fixed hardcoded event type check that was preventing workflow_dispatch from working

## Test Plan
- [x] Verified action.yml changes are syntactically correct
- [x] Confirmed workflow_dispatch events will now be allowed through the event type check
- [x] Added pr-number input parameter for manual PR number specification
- [ ] Test workflow_dispatch functionality in production