### PR TITLE
claude-code-security-review: Fix deprecated Haiku model in validate_api_access

### DIFF
--- a/claudecode/claude_api_client.py
+++ b/claudecode/claude_api_client.py
@@ -59,7 +59,7 @@ class ClaudeAPIClient:
         try:
             # Simple test call to verify API access
             self.client.messages.create(
-                model="claude-3-5-haiku-20241022",
+                model="claude-haiku-4-5-20251001",
                 max_tokens=10,
                 messages=[{"role": "user", "content": "Hello"}],
                 timeout=10


### PR DESCRIPTION
## Summary

- Update hardcoded model in `validate_api_access()` from `claude-3-5-haiku-20241022` (deprecated 2026-02-19) to `claude-haiku-4-5-20251001`
- The deprecated model causes the validation call to fail, which silently disables Claude-based false positive filtering for all findings
- Related upstream issue: https://github.com/anthropics/claude-code-security-review/issues/69

## Test Plan
- [x] Verify `validate_api_access()` succeeds with the new model
- [x] Confirm Claude filtering is no longer silently disabled in CI runs